### PR TITLE
feat: Add label selectors to tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ A single pipeline is simpler to operate, results in less drift across
 environments if more than one, becomes familiar across teams and departments,
 accomplishes shorter time-to-value and lower failure rates.
 
-A single pipeline does put tension on processes and in some cases it may be
-difficult to achieve a single pipeline for an application.
+A single pipeline does put tension on processes because new artifact versions
+can pile up waiting for the existing pipeline to complete.
 
 That all said, you can add your own pipeline template files and wire up
 applications to use them.
@@ -56,6 +56,10 @@ features you might need.
 
 After exploring the tutorial have a browse through the [example/](./example/)
 directory.
+
+```
+cd example/
+```
 
 Render all jsonnet to json:
 

--- a/example/config-defaults.jsonnet
+++ b/example/config-defaults.jsonnet
@@ -180,8 +180,8 @@ local spin = (import '../vendor/github.com/karlskewes/spin-libsonnet/spin.libson
       // teama edit accounts
       { name: 'prd-global-ec2-teama-edit', regions: ['ap-southeast-2', 'us-east-2'], keyPair: 'example-prd-global-spinnaker', labels: { stageBlock: 'production', cloudProvider: 'aws', cloud: 'aws', team: 'product', teama: true } },
       { name: 'prd-ap-southeast-2-eks-01-teama-edit', path: 'kubernetes/prd/ap-southeast-2-eks-01', labels: { stageBlock: 'production', cloudProvider: 'kubernetes', cloud: 'aws', team: 'product', teama: true, region: 'ap-southeast-2' } },
-      { name: 'prd-us-east-2-eks-01-teama-edit', path: 'kubernetes/prd/us-east-2-eks-01', labels: { stageBlock: 'production', cloudProvider: 'kubernetes', cloud: 'aws', team: 'product', teama: true, selfService: true, region: 'us-east-2' } },
-      { name: 'stg-ap-southeast-2-eks-01-teama-edit', path: 'kubernetes/stg/ap-southeast-2-eks-01', labels: { stageBlock: 'staging', cloudProvider: 'kubernetes', cloud: 'aws', team: 'product', teama: true, selfService: true, region: 'ap-southeast-2' } },
+      { name: 'prd-us-east-2-eks-01-teama-edit', path: 'kubernetes/prd/us-east-2-eks-01', labels: { stageBlock: 'production', cloudProvider: 'kubernetes', cloud: 'aws', team: 'product', teama: true, region: 'us-east-2' } },
+      { name: 'stg-ap-southeast-2-eks-01-teama-edit', path: 'kubernetes/stg/ap-southeast-2-eks-01', labels: { stageBlock: 'staging', cloudProvider: 'kubernetes', cloud: 'aws', team: 'product', teama: true, region: 'ap-southeast-2' } },
       { name: 'stg-global-ec2-teama-edit', regions: ['ap-southeast-2'], keyPair: 'example-stg-global-spinnaker', labels: { stageBlock: 'staging', cloudProvider: 'aws', cloud: 'aws', team: 'product', teama: true } },
     ],
   },

--- a/tests/test-e2e.pass.jsonnet
+++ b/tests/test-e2e.pass.jsonnet
@@ -198,7 +198,7 @@ local defaults = {
       { name: 'prd-global-ec2-product-edit', regions: ['ap-southeast-2', 'us-east-1'], keyPair: 'example-prd-global-spinnaker', labels: { stageBlock: 'production', cloudProvider: 'aws', cloud: 'aws', team: 'product', product: true } },
       { name: 'prd-ap-southeast-2-product-edit', path: 'prd/ap-southeast-2', labels: { stageBlock: 'production', cloudProvider: 'kubernetes', cloud: 'aws', team: 'product', product: true, region: 'ap-southeast-2' } },
       { name: 'prd-us-east-1-product-edit', path: 'prd/us-east-1', labels: { stageBlock: 'production', cloudProvider: 'kubernetes', cloud: 'aws', team: 'product', product: true, region: 'us-east-1' } },
-      { name: 'stg-us-east-1-product-edit', path: 'stg/us-east-1', labels: { stageBlock: 'staging', cloudProvider: 'kubernetes', cloud: 'aws', team: 'product', product: true, selfService: true, region: 'us-east-1' } },
+      { name: 'stg-us-east-1-product-edit', path: 'stg/us-east-1', labels: { stageBlock: 'staging', cloudProvider: 'kubernetes', cloud: 'aws', team: 'product', product: true, region: 'us-east-1' } },
       { name: 'stg-global-ec2-product-edit', regions: ['us-east-1'], keyPair: 'example-stg-global-spinnaker', labels: { stageBlock: 'staging', cloudProvider: 'aws', cloud: 'aws', team: 'product', product: true } },
     ],
   },


### PR DESCRIPTION
The project supports targeting cloud provider accounts based on any desired dimension through the use of label selectors. This was inspired by Kubernetes label selectors.

Defaults can be specified per team or other grouping and then overridden as necessary.